### PR TITLE
feat: refactor db structure and add migration & seeding scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,12 @@
     "lint:fix": "eslint src/**/*.ts --fix",
     "seed": "ts-node src/database/seeds/property.seed.ts",
     "db:seed": "npm run seed",
-    "migrate:create": "migrate-mongo create"
+    "db:reset": "ts-node src/database/scripts/reset-database.ts",
+    "db:reset:seed": "ts-node src/database/scripts/reset-database.ts seed",
+    "migrate:create": "migrate-mongo create",
+    "migrate:up": "migrate-mongo up",
+    "migrate:down": "migrate-mongo down",
+    "migrate:status": "migrate-mongo status"
   },
   "keywords": [
     "nodejs",

--- a/src/database/migrations/20250921143751-add-new-property-fields.js
+++ b/src/database/migrations/20250921143751-add-new-property-fields.js
@@ -1,0 +1,118 @@
+module.exports = {
+  /**
+   * @param db {import('mongodb').Db}
+   * @param client {import('mongodb').MongoClient}
+   * @returns {Promise<void>}
+   */
+  async up(db, client) {
+    console.log('🔄 Adding new property fields to existing documents...');
+    
+    // Get count of existing properties
+    const existingCount = await db.collection('properties').countDocuments();
+    console.log(`📊 Found ${existingCount} existing properties`);
+    
+    if (existingCount === 0) {
+      console.log('✅ No existing properties to migrate');
+      return;
+    }
+
+    // Add new fields with default values to all existing properties
+    const updateResult = await db.collection('properties').updateMany(
+      {}, // Update all documents
+      {
+        $set: {
+          // Set default values for new optional fields (only if they don't exist)
+          houseId: null,
+          streetAddress: null,
+          landmark: null,
+          area: null,
+          listingId: null,
+          inventoryStatus: null,
+          tenantType: null,
+          propertyCategory: null,
+          furnishingStatus: null,
+          availableFrom: null,
+          floor: null,
+          totalFloor: null,
+          yearOfConstruction: null,
+          rent: null,
+          serviceCharge: null,
+          advanceMonths: null,
+          cleanHygieneScore: null,
+          sunlightScore: null,
+          bathroomConditionsScore: null,
+          coverImage: null,
+          otherImages: []
+        }
+      }
+    );
+
+    console.log(`✅ Updated ${updateResult.modifiedCount} properties with new fields`);
+    
+    // Create indexes for new fields
+    console.log('🔄 Creating indexes for new fields...');
+    await db.collection('properties').createIndex({ area: 1, propertyCategory: 1 });
+    await db.collection('properties').createIndex({ inventoryStatus: 1, tenantType: 1 });
+    await db.collection('properties').createIndex({ rent: 1, bedrooms: 1 });
+    await db.collection('properties').createIndex({ houseId: 1 });
+    await db.collection('properties').createIndex({ listingId: 1 });
+    
+    console.log('✅ Indexes created successfully');
+    console.log('🎉 Migration completed successfully!');
+  },
+
+  /**
+   * @param db {import('mongodb').Db}
+   * @param client {import('mongodb').MongoClient}
+   * @returns {Promise<void>}
+   */
+  async down(db, client) {
+    console.log('🔄 Rolling back new property fields...');
+    
+    // Remove the new fields from all documents
+    const updateResult = await db.collection('properties').updateMany(
+      {},
+      {
+        $unset: {
+          houseId: '',
+          streetAddress: '',
+          landmark: '',
+          area: '',
+          listingId: '',
+          inventoryStatus: '',
+          tenantType: '',
+          propertyCategory: '',
+          furnishingStatus: '',
+          availableFrom: '',
+          floor: '',
+          totalFloor: '',
+          yearOfConstruction: '',
+          rent: '',
+          serviceCharge: '',
+          advanceMonths: '',
+          cleanHygieneScore: '',
+          sunlightScore: '',
+          bathroomConditionsScore: '',
+          coverImage: '',
+          otherImages: ''
+        }
+      }
+    );
+
+    console.log(`✅ Removed new fields from ${updateResult.modifiedCount} properties`);
+    
+    // Drop the new indexes
+    console.log('🔄 Dropping new indexes...');
+    try {
+      await db.collection('properties').dropIndex({ area: 1, propertyCategory: 1 });
+      await db.collection('properties').dropIndex({ inventoryStatus: 1, tenantType: 1 });
+      await db.collection('properties').dropIndex({ rent: 1, bedrooms: 1 });
+      await db.collection('properties').dropIndex({ houseId: 1 });
+      await db.collection('properties').dropIndex({ listingId: 1 });
+    } catch (error) {
+      console.log('⚠️  Some indexes may not exist, continuing...');
+    }
+    
+    console.log('✅ Rollback completed successfully!');
+  }
+};

--- a/src/database/models/property.model.ts
+++ b/src/database/models/property.model.ts
@@ -21,6 +21,29 @@ export interface IProperty extends Document {
   createdAt: Date;
   updatedAt: Date;
   lift: boolean;
+  
+  // New fields
+  houseId?: string;
+  streetAddress?: string;
+  landmark?: string;
+  area?: string;
+  listingId?: string;
+  inventoryStatus?: string;
+  tenantType?: string;
+  propertyCategory?: string;
+  furnishingStatus?: string;
+  availableFrom?: Date;
+  floor?: number;
+  totalFloor?: number;
+  yearOfConstruction?: number;
+  rent?: number;
+  serviceCharge?: number;
+  advanceMonths?: number;
+  cleanHygieneScore?: number;
+  sunlightScore?: number;
+  bathroomConditionsScore?: number;
+  coverImage?: string;
+  otherImages?: string[];
 }
 
 // Property schema definition
@@ -129,6 +152,130 @@ const PropertySchema = new Schema<IProperty>({
     type: Boolean,
     default: false,
     index: true
+  },
+  
+  // New fields
+  houseId: {
+    type: String,
+    trim: true,
+    maxlength: [50, 'House ID must be less than 50 characters'],
+    index: true
+  },
+  streetAddress: {
+    type: String,
+    trim: true,
+    maxlength: [500, 'Street address must be less than 500 characters']
+  },
+  landmark: {
+    type: String,
+    trim: true,
+    maxlength: [300, 'Landmark must be less than 300 characters']
+  },
+  area: {
+    type: String,
+    trim: true,
+    maxlength: [200, 'Area must be less than 200 characters'],
+    index: true
+  },
+  listingId: {
+    type: String,
+    trim: true,
+    maxlength: [50, 'Listing ID must be less than 50 characters'],
+    index: true
+  },
+  inventoryStatus: {
+    type: String,
+    trim: true,
+    enum: {
+      values: ['Looking for Rent', 'Looking for Sale', 'Looking for Lease', 'Available', 'Rented', 'Sold', 'Leased', 'Unavailable'],
+      message: 'Invalid inventory status'
+    }
+  },
+  tenantType: {
+    type: String,
+    trim: true,
+    enum: {
+      values: ['Family', 'Bachelor', 'Office', 'Commercial', 'Any'],
+      message: 'Invalid tenant type'
+    }
+  },
+  propertyCategory: {
+    type: String,
+    trim: true,
+    enum: {
+      values: ['Residential', 'Commercial', 'Industrial', 'Mixed'],
+      message: 'Invalid property category'
+    }
+  },
+  furnishingStatus: {
+    type: String,
+    trim: true,
+    enum: {
+      values: ['Furnished', 'Semi-Furnished', 'Non-Furnished'],
+      message: 'Invalid furnishing status'
+    }
+  },
+  availableFrom: {
+    type: Date
+  },
+  floor: {
+    type: Number,
+    min: [0, 'Floor cannot be negative'],
+    max: [200, 'Floor seems unrealistic']
+  },
+  totalFloor: {
+    type: Number,
+    min: [1, 'Total floor must be at least 1'],
+    max: [200, 'Total floor seems unrealistic']
+  },
+  yearOfConstruction: {
+    type: Number,
+    min: [1800, 'Year of construction seems too old'],
+    max: [new Date().getFullYear() + 5, 'Year of construction cannot be too far in future']
+  },
+  rent: {
+    type: Number,
+    min: [0, 'Rent cannot be negative'],
+    max: [10000000, 'Rent seems unrealistic']
+  },
+  serviceCharge: {
+    type: Number,
+    min: [0, 'Service charge cannot be negative'],
+    max: [1000000, 'Service charge seems unrealistic']
+  },
+  advanceMonths: {
+    type: Number,
+    min: [0, 'Advance months cannot be negative'],
+    max: [24, 'Advance months seems too high']
+  },
+  cleanHygieneScore: {
+    type: Number,
+    min: [1, 'Clean hygiene score must be between 1-10'],
+    max: [10, 'Clean hygiene score must be between 1-10']
+  },
+  sunlightScore: {
+    type: Number,
+    min: [1, 'Sunlight score must be between 1-10'],
+    max: [10, 'Sunlight score must be between 1-10']
+  },
+  bathroomConditionsScore: {
+    type: Number,
+    min: [1, 'Bathroom conditions score must be between 1-10'],
+    max: [10, 'Bathroom conditions score must be between 1-10']
+  },
+  coverImage: {
+    type: String,
+    trim: true,
+    maxlength: [500, 'Cover image URL must be less than 500 characters']
+  },
+  otherImages: {
+    type: [String],
+    validate: {
+      validator: function(images: string[]) {
+        return images.length <= 20; // Max 20 images
+      },
+      message: 'Cannot have more than 20 images'
+    }
   }
 }, {
   timestamps: true, // Automatically adds createdAt and updatedAt fields
@@ -160,16 +307,27 @@ PropertySchema.index({ bedrooms: 1, size: 1 });
 PropertySchema.index({ firstOwner: 1, onLoan: 1 });
 PropertySchema.index({ createdAt: -1 }); // For sorting by creation date
 PropertySchema.index({ email: 1, phone: 1 }); // Composite index for contact info
+PropertySchema.index({ area: 1, propertyCategory: 1 }); // New indexes
+PropertySchema.index({ inventoryStatus: 1, tenantType: 1 });
+PropertySchema.index({ rent: 1, bedrooms: 1 });
+PropertySchema.index({ houseId: 1 });
+PropertySchema.index({ listingId: 1 });
 
 // Text index for search functionality
 PropertySchema.index({
   propertyName: 'text',
   location: 'text',
-  notes: 'text'
+  notes: 'text',
+  streetAddress: 'text',
+  landmark: 'text',
+  area: 'text'
 }, {
   weights: {
     propertyName: 10,
+    streetAddress: 8,
     location: 5,
+    area: 5,
+    landmark: 3,
     notes: 1
   },
   name: 'property_text_index'

--- a/src/database/scripts/reset-database.ts
+++ b/src/database/scripts/reset-database.ts
@@ -1,0 +1,97 @@
+import { connectToDatabase, disconnectFromDatabase } from '../config/connection';
+import { Property } from '../models/property.model';
+
+/**
+ * Reset the entire database - drops all data and recreates with fresh schema
+ * This is useful when you have major schema changes and want a clean start
+ */
+export const resetDatabase = async (): Promise<void> => {
+  try {
+    console.log('🔄 Starting database reset...');
+
+    // Connect to database
+    await connectToDatabase();
+
+    // Drop the entire properties collection
+    console.log('🗑️  Dropping properties collection...');
+    try {
+      await Property.collection.drop();
+      console.log('✅ Properties collection dropped');
+    } catch (error: any) {
+      if (error.code === 26) {
+        console.log('ℹ️  Properties collection does not exist, skipping drop');
+      } else {
+        throw error;
+      }
+    }
+
+    // Drop migration collections to reset migration state
+    console.log('🗑️  Clearing migration history...');
+    try {
+      const db = Property.db;
+      await db.collection('migrations_changelog').drop();
+      await db.collection('migrations_changelog_lock').drop();
+      console.log('✅ Migration history cleared');
+    } catch (error: any) {
+      if (error.code === 26) {
+        console.log('ℹ️  Migration collections do not exist, skipping drop');
+      } else {
+        console.log('⚠️  Warning: Could not clear migration history:', error.message);
+      }
+    }
+
+    // The collection will be recreated automatically when we insert new data
+    // with the new schema and indexes defined in the model
+    console.log('✅ Database reset completed!');
+    console.log('💡 Run "npm run db:seed" to populate with new sample data');
+
+  } catch (error) {
+    console.error('❌ Error resetting database:', error);
+    throw error;
+  }
+};
+
+/**
+ * Quick reset and reseed in one command
+ */
+export const resetAndSeed = async (): Promise<void> => {
+  try {
+    await resetDatabase();
+    
+    // Import and run seeding
+    const { seedProperties } = await import('../seeds/property.seed');
+    await seedProperties();
+    
+    console.log('🎉 Database reset and seeded successfully!');
+  } catch (error) {
+    console.error('❌ Error during reset and seed:', error);
+    throw error;
+  }
+};
+
+/**
+ * Main function to run database reset
+ */
+const runReset = async (): Promise<void> => {
+  try {
+    const resetType = process.argv[2] || 'reset';
+    
+    if (resetType === 'seed') {
+      await resetAndSeed();
+    } else {
+      await resetDatabase();
+    }
+  } catch (error) {
+    console.error('❌ Reset failed:', error);
+    process.exit(1);
+  } finally {
+    await disconnectFromDatabase();
+    console.log('👋 Database connection closed');
+    process.exit(0);
+  }
+};
+
+// Run reset if this file is executed directly
+if (require.main === module) {
+  runReset();
+}

--- a/src/database/seeds/property.seed.ts
+++ b/src/database/seeds/property.seed.ts
@@ -22,6 +22,31 @@ const sampleProperties = [
     paperworkUpdated: true,
     onLoan: false,
     lift: true,
+    // New fields
+    houseId: 'A-01',
+    streetAddress: 'Downtown, City Center, Metropolitan Area',
+    landmark: 'Near Central Mall',
+    area: 'Downtown & City Center',
+    listingId: 'RE-SALE-1',
+    inventoryStatus: 'Looking for Sale',
+    tenantType: 'Family',
+    propertyCategory: 'Residential',
+    furnishingStatus: 'Furnished',
+    availableFrom: new Date('2025-01-01'),
+    floor: 5,
+    totalFloor: 10,
+    yearOfConstruction: 2020,
+    rent: 0, // Not applicable for sale
+    serviceCharge: 0,
+    advanceMonths: 0,
+    cleanHygieneScore: 9,
+    sunlightScore: 8,
+    bathroomConditionsScore: 9,
+    coverImage: 'https://example.com/images/luxury-apartment-cover.jpg',
+    otherImages: [
+      'https://example.com/images/luxury-apartment-1.jpg',
+      'https://example.com/images/luxury-apartment-2.jpg'
+    ]
   },
   {
     name: 'Jane Smith',
@@ -40,6 +65,32 @@ const sampleProperties = [
     paperworkUpdated: true,
     onLoan: false,
     lift: false,
+    // New fields
+    houseId: 'H-05',
+    streetAddress: 'Green Valley, Suburban District',
+    landmark: 'Opposite Green Park',
+    area: 'Green Valley & Suburbs',
+    listingId: 'RE-RENT-2',
+    inventoryStatus: 'Looking for Rent',
+    tenantType: 'Family',
+    propertyCategory: 'Residential',
+    furnishingStatus: 'Semi-Furnished',
+    availableFrom: new Date('2025-02-01'),
+    floor: 0, // Ground floor
+    totalFloor: 2,
+    yearOfConstruction: 2018,
+    rent: 25000,
+    serviceCharge: 3000,
+    advanceMonths: 2,
+    cleanHygieneScore: 8,
+    sunlightScore: 9,
+    bathroomConditionsScore: 8,
+    coverImage: 'https://example.com/images/family-house-cover.jpg',
+    otherImages: [
+      'https://example.com/images/family-house-1.jpg',
+      'https://example.com/images/family-house-2.jpg',
+      'https://example.com/images/family-house-garden.jpg'
+    ]
   },
   {
     name: 'Mike Johnson',
@@ -58,6 +109,32 @@ const sampleProperties = [
     paperworkUpdated: true,
     onLoan: false,
     lift: true,
+    // New fields
+    houseId: 'V-12',
+    streetAddress: 'Hillside Premium District, Elite Avenue',
+    landmark: 'Near Premium Club',
+    area: 'Hillside & Premium District',
+    listingId: 'RE-SALE-3',
+    inventoryStatus: 'Looking for Sale',
+    tenantType: 'Family',
+    propertyCategory: 'Residential',
+    furnishingStatus: 'Furnished',
+    availableFrom: new Date('2025-03-01'),
+    floor: 0, // Ground floor villa
+    totalFloor: 3,
+    yearOfConstruction: 2022,
+    rent: 0,
+    serviceCharge: 0,
+    advanceMonths: 0,
+    cleanHygieneScore: 10,
+    sunlightScore: 10,
+    bathroomConditionsScore: 10,
+    coverImage: 'https://example.com/images/luxury-villa-cover.jpg',
+    otherImages: [
+      'https://example.com/images/luxury-villa-pool.jpg',
+      'https://example.com/images/luxury-villa-interior.jpg',
+      'https://example.com/images/luxury-villa-garden.jpg'
+    ]
   },
   {
     name: 'Sarah Wilson',
@@ -76,6 +153,30 @@ const sampleProperties = [
     paperworkUpdated: false,
     onLoan: true,
     lift: true,
+    // New fields
+    houseId: 'S-08',
+    streetAddress: 'Business District, Corporate Avenue',
+    landmark: 'Next to Metro Station',
+    area: 'Business District',
+    listingId: 'RE-RENT-4',
+    inventoryStatus: 'Looking for Rent',
+    tenantType: 'Bachelor',
+    propertyCategory: 'Residential',
+    furnishingStatus: 'Furnished',
+    availableFrom: new Date('2025-01-15'),
+    floor: 8,
+    totalFloor: 15,
+    yearOfConstruction: 2021,
+    rent: 18000,
+    serviceCharge: 2500,
+    advanceMonths: 3,
+    cleanHygieneScore: 7,
+    sunlightScore: 6,
+    bathroomConditionsScore: 8,
+    coverImage: 'https://example.com/images/studio-apartment-cover.jpg',
+    otherImages: [
+      'https://example.com/images/studio-apartment-interior.jpg'
+    ]
   },
   {
     name: 'David Brown',
@@ -94,6 +195,31 @@ const sampleProperties = [
     paperworkUpdated: true,
     onLoan: false,
     lift: true,
+    // New fields
+    houseId: 'C-15',
+    streetAddress: 'Business Park Zone A, Tech Boulevard',
+    landmark: 'Opposite IT Tower',
+    area: 'Business Park Zone A',
+    listingId: 'RE-LEASE-5',
+    inventoryStatus: 'Looking for Lease',
+    tenantType: 'Office',
+    propertyCategory: 'Commercial',
+    furnishingStatus: 'Non-Furnished',
+    availableFrom: new Date('2025-04-01'),
+    floor: 3,
+    totalFloor: 8,
+    yearOfConstruction: 2019,
+    rent: 80000,
+    serviceCharge: 15000,
+    advanceMonths: 6,
+    cleanHygieneScore: 9,
+    sunlightScore: 8,
+    bathroomConditionsScore: 9,
+    coverImage: 'https://example.com/images/office-space-cover.jpg',
+    otherImages: [
+      'https://example.com/images/office-space-interior.jpg',
+      'https://example.com/images/office-space-parking.jpg'
+    ]
   },
 ];
 

--- a/src/validators/property.validator.ts
+++ b/src/validators/property.validator.ts
@@ -22,6 +22,39 @@ export const CategoryEnum = z.enum([
   'buy'
 ]);
 
+// New enums for the additional fields
+export const InventoryStatusEnum = z.enum([
+  'Looking for Rent',
+  'Looking for Sale', 
+  'Looking for Lease',
+  'Available',
+  'Rented',
+  'Sold',
+  'Leased',
+  'Unavailable'
+]);
+
+export const TenantTypeEnum = z.enum([
+  'Family',
+  'Bachelor', 
+  'Office',
+  'Commercial',
+  'Any'
+]);
+
+export const PropertyCategoryEnum = z.enum([
+  'Residential',
+  'Commercial',
+  'Industrial',
+  'Mixed'
+]);
+
+export const FurnishingStatusEnum = z.enum([
+  'Furnished',
+  'Semi-Furnished',
+  'Non-Furnished'
+]);
+
 // Base property schema with all required fields
 export const PropertySchema = z.object({
   name: z.string().min(1, 'Name is required').max(100, 'Name must be less than 100 characters'),
@@ -40,6 +73,29 @@ export const PropertySchema = z.object({
   lift: z.boolean().default(false),
   paperworkUpdated: z.boolean().default(false),
   onLoan: z.boolean().default(false),
+  
+  // New optional fields
+  houseId: z.string().max(50, 'House ID must be less than 50 characters').optional(),
+  streetAddress: z.string().max(500, 'Street address must be less than 500 characters').optional(),
+  landmark: z.string().max(300, 'Landmark must be less than 300 characters').optional(),
+  area: z.string().max(200, 'Area must be less than 200 characters').optional(),
+  listingId: z.string().max(50, 'Listing ID must be less than 50 characters').optional(),
+  inventoryStatus: InventoryStatusEnum.optional(),
+  tenantType: TenantTypeEnum.optional(),
+  propertyCategory: PropertyCategoryEnum.optional(),
+  furnishingStatus: FurnishingStatusEnum.optional(),
+  availableFrom: z.coerce.date().optional(),
+  floor: z.number().min(0, 'Floor cannot be negative').max(200, 'Floor seems unrealistic').optional(),
+  totalFloor: z.number().min(1, 'Total floor must be at least 1').max(200, 'Total floor seems unrealistic').optional(),
+  yearOfConstruction: z.number().min(1800, 'Year of construction seems too old').max(new Date().getFullYear() + 5, 'Year of construction cannot be too far in future').optional(),
+  rent: z.number().min(0, 'Rent cannot be negative').max(10000000, 'Rent seems unrealistic').optional(),
+  serviceCharge: z.number().min(0, 'Service charge cannot be negative').max(1000000, 'Service charge seems unrealistic').optional(),
+  advanceMonths: z.number().min(0, 'Advance months cannot be negative').max(24, 'Advance months seems too high').optional(),
+  cleanHygieneScore: z.number().min(1, 'Clean hygiene score must be between 1-10').max(10, 'Clean hygiene score must be between 1-10').optional(),
+  sunlightScore: z.number().min(1, 'Sunlight score must be between 1-10').max(10, 'Sunlight score must be between 1-10').optional(),
+  bathroomConditionsScore: z.number().min(1, 'Bathroom conditions score must be between 1-10').max(10, 'Bathroom conditions score must be between 1-10').optional(),
+  coverImage: z.string().max(500, 'Cover image URL must be less than 500 characters').optional(),
+  otherImages: z.array(z.string()).max(20, 'Cannot have more than 20 images').optional(),
 });
 
 // Create property request schema (for POST requests)
@@ -58,6 +114,18 @@ export const PropertyFiltersSchema = z.object({
   location: z.string().optional(),
   firstOwner: z.string().transform((val) => val === 'true').optional(),
   onLoan: z.string().transform((val) => val === 'true').optional(),
+  
+  // New filter fields
+  area: z.string().optional(),
+  inventoryStatus: InventoryStatusEnum.optional(),
+  tenantType: TenantTypeEnum.optional(),
+  propertyCategory: PropertyCategoryEnum.optional(),
+  furnishingStatus: FurnishingStatusEnum.optional(),
+  minRent: z.string().transform((val) => parseInt(val, 10)).optional(),
+  maxRent: z.string().transform((val) => parseInt(val, 10)).optional(),
+  floor: z.string().transform((val) => parseInt(val, 10)).optional(),
+  houseId: z.string().optional(),
+  listingId: z.string().optional(),
 });
 
 // Response schemas
@@ -89,3 +157,7 @@ export type PropertiesListResponse = z.infer<typeof PropertiesListResponseSchema
 export type ErrorResponse = z.infer<typeof ErrorResponseSchema>;
 export type PropertyType = z.infer<typeof PropertyTypeEnum>;
 export type Category = z.infer<typeof CategoryEnum>;
+export type InventoryStatus = z.infer<typeof InventoryStatusEnum>;
+export type TenantType = z.infer<typeof TenantTypeEnum>;
+export type PropertyCategory = z.infer<typeof PropertyCategoryEnum>;
+export type FurnishingStatus = z.infer<typeof FurnishingStatusEnum>;


### PR DESCRIPTION
efactor: Add new property fields and migration scripts

This PR introduces a significant update to the property data model and related scripts to support a wider range of property attributes.
Summary of Changes

    Property Model & Schema: Added 20 new optional fields to the Property model and Mongoose schema, including houseId, rent, furnishingStatus, and various scores for hygiene and sunlight.

    Database Migration: Created a new migration script (20250921143751-add-new-property-fields.js) that safely updates existing documents by adding these new fields with null or empty array default values and creates new indexes for improved search performance.

    Development Scripts: Added new npm scripts for database management:

        npm run db:reset: Resets the database by dropping the properties and migration collections.

        npm run db:reset:seed: Resets the database and reseeds it with new sample data.

    Validation & Seeding: Updated Zod validators and sample seed data to include the new fields.

How to Test

    Pull the branch and install dependencies: npm install

    Run the migration to apply the schema changes to your database: npm run migrate:up

    Alternatively, use the new reset and seed command to start with a fresh, populated database: npm run db:reset:seed

    Verify that the properties collection now includes documents with the new fields and that the new indexes have been created.

    Check that the API endpoints continue to work as expected with both old and new data structures.