### PR TITLE
feat: added isConfirmed field to property table and set it as a defau…

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -151,6 +151,9 @@ Retrieve property listings with optional filtering and pagination.
 | `floor` | integer | Specific floor number | `?floor=5` |
 | `houseId` | string | House ID search | `?houseId=H001` |
 | `listingId` | string | Listing ID search | `?listingId=L001` |
+| `isConfirmed` | boolean | Show confirmed/unconfirmed properties | `?isConfirmed=false` |
+
+**Note**: By default, the API only returns properties where `isConfirmed` is `true`. To see unconfirmed properties, explicitly set `isConfirmed=false`.
 
 **Example Request:**
 ```
@@ -177,6 +180,7 @@ GET /properties?page=1&limit=10&category=rent&propertyType=apartment&bedrooms=2&
       "notes": "Sea facing apartment with parking",
       "firstOwner": true,
       "lift": true,
+      "isConfirmed": true,
       "paperworkUpdated": true,
       "onLoan": false,
       "houseId": "H001",
@@ -336,6 +340,7 @@ interface Property {
   category: Category;             // rent, sale, lease, buy
   firstOwner: boolean;            // Is first owner
   lift: boolean;                  // Has elevator
+  isConfirmed: boolean;           // Property listing confirmed
   paperworkUpdated: boolean;      // Paperwork status
   onLoan: boolean;               // Property on loan
 

--- a/src/database/migrations/20250922000000-add-isConfirmed-field-to-properties.js
+++ b/src/database/migrations/20250922000000-add-isConfirmed-field-to-properties.js
@@ -1,0 +1,26 @@
+/**
+ * Migration to add isConfirmed field to all existing properties
+ * Set default value to false for all existing records
+ */
+
+module.exports = {
+  async up(db, client) {
+    // Add isConfirmed field with default value true to all existing properties
+    await db.collection('properties').updateMany(
+      { isConfirmed: { $exists: false } }, // Only update documents that don't have the field
+      { $set: { isConfirmed: true } }
+    );
+
+    console.log('Added isConfirmed field to all existing properties with default value true');
+  },
+
+  async down(db, client) {
+    // Remove isConfirmed field from all properties
+    await db.collection('properties').updateMany(
+      {},
+      { $unset: { isConfirmed: "" } }
+    );
+    
+    console.log('Removed isConfirmed field from all properties');
+  }
+};

--- a/src/database/models/property.model.ts
+++ b/src/database/models/property.model.ts
@@ -21,6 +21,7 @@ export interface IProperty extends Document {
   createdAt: Date;
   updatedAt: Date;
   lift: boolean;
+  isConfirmed: boolean;
   
   // New fields
   houseId?: string;
@@ -143,6 +144,11 @@ const PropertySchema = new Schema<IProperty>({
   lift: { 
     type: Boolean,
     default: false,  // Set a default value (e.g., false for no lift)
+  },
+  isConfirmed: {
+    type: Boolean,
+    default: false,
+    index: true
   },
   paperworkUpdated: {
     type: Boolean,
@@ -303,6 +309,7 @@ PropertySchema.index({ propertyType: 1, category: 1 });
 PropertySchema.index({ location: 1, propertyType: 1 });
 PropertySchema.index({ bedrooms: 1, size: 1 });
 PropertySchema.index({ firstOwner: 1, onLoan: 1 });
+PropertySchema.index({ isConfirmed: 1 }); // Index for confirmed properties
 PropertySchema.index({ createdAt: -1 }); // For sorting by creation date
 PropertySchema.index({ email: 1, phone: 1 }); // Composite index for contact info
 PropertySchema.index({ area: 1, propertyCategory: 1 }); // New indexes

--- a/src/database/seeds/property.seed.ts
+++ b/src/database/seeds/property.seed.ts
@@ -22,6 +22,7 @@ const sampleProperties = [
     paperworkUpdated: true,
     onLoan: false,
     lift: true,
+    isConfirmed: true,
     // New fields
     houseId: 'A-01',
     streetAddress: 'Downtown, City Center, Metropolitan Area',
@@ -65,6 +66,7 @@ const sampleProperties = [
     paperworkUpdated: true,
     onLoan: false,
     lift: false,
+    isConfirmed: true,
     // New fields
     houseId: 'H-05',
     streetAddress: 'Green Valley, Suburban District',
@@ -109,6 +111,7 @@ const sampleProperties = [
     paperworkUpdated: true,
     onLoan: false,
     lift: true,
+    isConfirmed: true,
     // New fields
     houseId: 'V-12',
     streetAddress: 'Hillside Premium District, Elite Avenue',
@@ -153,6 +156,7 @@ const sampleProperties = [
     paperworkUpdated: false,
     onLoan: true,
     lift: true,
+    isConfirmed: true,
     // New fields
     houseId: 'S-08',
     streetAddress: 'Business District, Corporate Avenue',
@@ -195,6 +199,7 @@ const sampleProperties = [
     paperworkUpdated: true,
     onLoan: false,
     lift: true,
+    isConfirmed: true,
     // New fields
     houseId: 'C-15',
     streetAddress: 'Business Park Zone A, Tech Boulevard',

--- a/src/validators/property.validator.ts
+++ b/src/validators/property.validator.ts
@@ -72,6 +72,7 @@ export const PropertySchema = z.object({
   notes: z.string().max(1000, 'Notes must be less than 1000 characters').optional(),
   firstOwner: z.boolean().default(false),
   lift: z.boolean().default(false),
+  isConfirmed: z.boolean().default(false),
   paperworkUpdated: z.boolean().default(false),
   onLoan: z.boolean().default(false),
   
@@ -120,6 +121,7 @@ export const PropertyFiltersSchema = z.object({
   location: z.string().optional(),
   firstOwner: z.string().transform((val) => val === 'true').optional(),
   onLoan: z.string().transform((val) => val === 'true').optional(),
+  isConfirmed: z.string().transform((val) => val === 'true').optional(),
   
   // New filter fields
   area: z.string().optional(),


### PR DESCRIPTION
## Summary

This PR introduces the **`isConfirmed`** field to the Property model and related services.  
By default, only confirmed properties (`isConfirmed=true`) will be returned in API responses, unless explicitly requested otherwise.  

---

## Changes

### 📄 Documentation
- Updated `API_DOCUMENTATION.md` to:
  - Add `isConfirmed` as a query filter.
  - Document default behavior (only confirmed properties returned unless `isConfirmed=false` is specified).
  - Extend property examples and interface definition with `isConfirmed`.

### 🗄️ Database
- **Migration:** Added `isConfirmed` field to all existing properties with default value `true`.
- **Model (`property.model.ts`):**
  - Added `isConfirmed` field with default `false` and indexing for efficient queries.
- **Seeds:** Updated sample properties to include `isConfirmed`.

### ⚙️ Service Layer
- **PropertyService:**
  - Default filter ensures only confirmed properties are returned.
  - `getListingById` updated to optionally include unconfirmed properties.
  - `getPropertiesByCategory`, `getAvailableProperties`, and aggregate queries updated to respect `isConfirmed`.
  - Property response now includes `isConfirmed`.

### ✅ Validation
- **Zod Validator (`property.validator.ts`):**
  - Added validation and default value for `isConfirmed`.
  - Added `isConfirmed` as a filter option.

---

## Impact

- **Breaking Change:** API will now **only return confirmed properties by default**.  
- Clients need to explicitly set `isConfirmed=false` to fetch unconfirmed properties.  
- Improves data quality and prevents accidental exposure of unreviewed/unconfirmed listings.  

---

## Testing

- [x] Migration tested locally – existing properties updated with `isConfirmed=true`.
- [x] Verified new seed data includes `isConfirmed`.
- [x] Confirmed API filters work correctly with `isConfirmed` query param.
- [x] Checked validators for correct parsing of boolean query strings.

---

## Next Steps

- Update CMS/Admin dashboard to allow toggling property confirmation status.  
- Communicate new default filtering behavior to frontend teams.
